### PR TITLE
Fixed array implosion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
+env:
+  global:
+  - DOCKER_VERSION="1.9.1-0~trusty"
 sudo: required
 services: docker
 before_install:
+  - sudo apt-get update
+  - sudo apt-get remove docker-engine -yq
+  - sudo apt-get install docker-engine=$DOCKER_VERSION -yq --no-install-suggests --no-install-recommends --force-yes -o Dpkg::Options::="--force-confnew"
   - phpenv config-add travis-php.ini
   - docker run -d -p 127.0.0.1:6379:6379 redislabs/redisearch:latest --protected-mode no --loadmodule /var/lib/redis/modules/redisearch.so
 language: php

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 services: docker
 before_install:
   - phpenv config-add travis-php.ini
-  - docker run -d -p 6379:6379 redislabs/redisearch:latest --protected-mode no --loadmodule /var/lib/redis/modules/redisearch.so
+  - docker run -d -p 127.0.0.1:6379:6379 redislabs/redisearch:latest --protected-mode no --loadmodule /var/lib/redis/modules/redisearch.so
 language: php
 php:
   - '7.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
-env:
-  global:
-  - DOCKER_VERSION="1.9.1-0~trusty"
 sudo: required
 services: docker
 before_install:
-  - sudo apt-get update
-  - sudo apt-get remove docker-engine -yq
-  - sudo apt-get install docker-engine=$DOCKER_VERSION -yq --no-install-suggests --no-install-recommends --force-yes -o Dpkg::Options::="--force-confnew"
   - phpenv config-add travis-php.ini
-  - docker run -d -p 127.0.0.1:6379:6379 redislabs/redisearch:latest --protected-mode no --loadmodule /var/lib/redis/modules/redisearch.so
+  - docker run -d -p 6379:6379 redislabs/redisearch:latest
 language: php
 php:
   - '7.0'

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -48,13 +48,13 @@ class Builder implements BuilderInterface
 
     public function inFields(int $number, array $fields): BuilderInterface
     {
-        $this->inFields = "INFIELDS $number {implode(' ', $fields)}";
+        $this->inFields = "INFIELDS $number ".implode(' ', $fields);
         return $this;
     }
 
     public function inKeys(int $number, array $keys): BuilderInterface
     {
-        $this->inKeys = "INKEYS $number {implode(' ', $keys)}";
+        $this->inKeys = "INKEYS $number ".implode(' ', $keys);
         return $this;
     }
 

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -38,7 +38,7 @@ abstract class AbstractTestCase extends TestCase
             getenv('REDIS_HOST') ?? '127.0.0.1',
             getenv('REDIS_PORT') ?? 6379
         );
-        $client->select(getenv('REDIS_DB') ?? 0);
+        // $client->select(getenv('REDIS_DB') ?? 0);
         return new RedisClient($client);
     }
 
@@ -48,7 +48,7 @@ abstract class AbstractTestCase extends TestCase
             'scheme' => 'tcp',
             'host' => getenv('REDIS_HOST') ?? '127.0.0.1',
             'port' => getenv('REDIS_PORT') ?? 6379,
-            'database' => getenv('REDIS_DB') ?? 0,
+            // 'database' => getenv('REDIS_DB') ?? 0,
         ]);
         $redis->connect();
         return new RedisClient($redis);


### PR DESCRIPTION
As stated in
http://www.php.net/manual/en/language.types.string.php#language.types.string.parsing.complex, “using single curly braces ({}) will not work for accessing the return values of functions”.

Fixes #21.