### PR TITLE
Noindex fields

### DIFF
--- a/src/Fields/GeoField.php
+++ b/src/Fields/GeoField.php
@@ -4,8 +4,20 @@ namespace Ehann\RediSearch\Fields;
 
 class GeoField extends AbstractField
 {
+    use Noindex;
+
     public function getType(): string
     {
         return 'GEO';
+    }
+
+    public function getTypeDefinition(): array
+    {
+        $properties = parent::getTypeDefinition();
+        if ($this->isNoindex()) {
+            $properties[] = 'NOINDEX';
+        }
+
+        return $properties;
     }
 }

--- a/src/Fields/Noindex.php
+++ b/src/Fields/Noindex.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ehann\RediSearch\Fields;
+
+trait Noindex
+{
+    protected $isNoindex = false;
+
+    public function isNoindex(): bool
+    {
+        return $this->isNoindex;
+    }
+
+    public function setNoindex(bool $noindex)
+    {
+        $this->isNoindex = $noindex;
+        return $this;
+    }
+}

--- a/src/Fields/NumericField.php
+++ b/src/Fields/NumericField.php
@@ -5,6 +5,7 @@ namespace Ehann\RediSearch\Fields;
 class NumericField extends AbstractField
 {
     use Sortable;
+    use Noindex;
 
     public function getType(): string
     {
@@ -16,6 +17,9 @@ class NumericField extends AbstractField
         $properties = parent::getTypeDefinition();
         if ($this->isSortable()) {
             $properties[] = 'SORTABLE';
+        }
+        if ($this->isNoindex()) {
+            $properties[] = 'NOINDEX';
         }
         return $properties;
     }

--- a/src/Fields/TextField.php
+++ b/src/Fields/TextField.php
@@ -5,6 +5,7 @@ namespace Ehann\RediSearch\Fields;
 class TextField extends AbstractField
 {
     use Sortable;
+    use Noindex;
 
     protected $weight = 1.0;
     protected $noStem = false;
@@ -46,6 +47,9 @@ class TextField extends AbstractField
         $properties[] = $this->getWeight();
         if ($this->isSortable()) {
             $properties[] = 'SORTABLE';
+        }
+        if ($this->isNoindex()) {
+            $properties[] = 'NOINDEX';
         }
         return $properties;
     }

--- a/src/Index.php
+++ b/src/Index.php
@@ -76,22 +76,24 @@ class Index extends AbstractIndex implements IndexInterface
      * @param string $name
      * @param float $weight
      * @param bool $sortable
+     * @param bool $noindex
      * @return IndexInterface
      */
-    public function addTextField(string $name, float $weight = 1.0, bool $sortable = false): IndexInterface
+    public function addTextField(string $name, float $weight = 1.0, bool $sortable = false, bool $noindex = false): IndexInterface
     {
-        $this->$name = (new TextField($name))->setSortable($sortable)->setWeight($weight);
+        $this->$name = (new TextField($name))->setSortable($sortable)->setNoindex($noindex)->setWeight($weight);
         return $this;
     }
 
     /**
      * @param string $name
      * @param bool $sortable
+     * @param bool $noindex
      * @return IndexInterface
      */
-    public function addNumericField(string $name, bool $sortable = false): IndexInterface
+    public function addNumericField(string $name, bool $sortable = false, bool $noindex = false): IndexInterface
     {
-        $this->$name = (new NumericField($name))->setSortable($sortable);
+        $this->$name = (new NumericField($name))->setSortable($sortable)->setNoindex($noindex);
         return $this;
     }
 
@@ -99,9 +101,9 @@ class Index extends AbstractIndex implements IndexInterface
      * @param string $name
      * @return IndexInterface
      */
-    public function addGeoField(string $name): IndexInterface
+    public function addGeoField(string $name, bool $noindex = false): IndexInterface
     {
-        $this->$name = (new GeoField($name));
+        $this->$name = (new GeoField($name))->setNoindex($noindex);
         return $this;
     }
 

--- a/src/IndexInterface.php
+++ b/src/IndexInterface.php
@@ -21,9 +21,9 @@ interface IndexInterface extends BuilderInterface
     public function setNoOffsetsEnabled(bool $noOffsetsEnabled): IndexInterface;
     public function isNoFieldsEnabled(): bool;
     public function setNoFieldsEnabled(bool $noFieldsEnabled): IndexInterface;
-    public function addTextField(string $name, float $weight = 1.0): IndexInterface;
-    public function addNumericField(string $name): IndexInterface;
-    public function addGeoField(string $name): IndexInterface;
+    public function addTextField(string $name, float $weight = 1.0, bool $noindex = false): IndexInterface;
+    public function addNumericField(string $name, bool $noindex = false): IndexInterface;
+    public function addGeoField(string $name, bool $noindex = false): IndexInterface;
     public function add($document): bool;
     public function addMany(array $documents, $disableAtomicity = false);
     public function replace($document): bool;

--- a/tests/RediSearch/IndexTest.php
+++ b/tests/RediSearch/IndexTest.php
@@ -99,6 +99,19 @@ class IndexTest extends AbstractTestCase
         $this->assertTrue($result);
     }
 
+    public function testCreateIndexWithNoindexFields()
+    {
+        $indexName = 'IndexWithNoindexFields';
+        $index = (new TestIndex($this->redisClient, $indexName))
+            ->addTextField('title', true)
+            ->addTextField('text_noindex', true, true)
+            ->addNumericField('numeric_noindex', true)
+            ->addGeoField('geo_noindex', true);
+
+        $result = $index->create();
+        $this->assertTrue($result);
+    }
+
     public function testAddDocumentWithZeroScore()
     {
         $this->subject->create();

--- a/tests/RediSearch/Query/BuilderTest.php
+++ b/tests/RediSearch/Query/BuilderTest.php
@@ -22,7 +22,8 @@ class BuilderTest extends AbstractTestCase
             ->addTextField('author')
             ->addNumericField('price')
             ->addNumericField('stock')
-            ->addGeoField('location');
+            ->addGeoField('location')
+            ->addTextField('private', 1.0, false, true);
         $index->create();
         $index->makeDocument();
         $this->expectedResult1 = [
@@ -47,6 +48,7 @@ class BuilderTest extends AbstractTestCase
             'price' => 18.95,
             'stock' => 11,
             'location' => new GeoLocation(10.9190500, 52.0504100),
+            'private' => 'classified'
         ];
         $index->add($this->expectedResult3);
         $this->subject = (new Builder($this->redisClient, $this->indexName));
@@ -62,6 +64,12 @@ class BuilderTest extends AbstractTestCase
         $result = $this->subject->search('Shoes');
 
         $this->assertTrue($result->getCount() === 1);
+    }
+
+    /* This should not be indexed and should therefore return zero results */
+    public function testUnindexed() {
+        $result = $this->subject->search('classified');
+        $this->assertTrue($result->getCount() === 0);
     }
 
     public function testSearchWithReturn()


### PR DESCRIPTION
Hi, 

Thanks for creating this wrapper to RediSearch, it's really great!

Currently redisearch-php throws an exception if you attempt to index documents with fields not included in the index definition.  This pull request allows you to specify NOINDEX fields when creating an index.

I _think_ I covered all of the surface area needed to add the functionality but am not very familiar with composer so let me know if I missed something obvious.

I ran `./vendor/bin/robo build` and everything is green on my local machines.

Cheers!
Mike