### PR TITLE
Adding support for TAG fields in index

### DIFF
--- a/src/Fields/TagField.php
+++ b/src/Fields/TagField.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Ehann\RediSearch\Fields;
+
+class TagField extends AbstractField
+{
+    use Sortable;
+    use Noindex;
+
+    protected $separator = ',';
+
+    public function getType(): string
+    {
+        return 'TAG';
+    }
+
+    public function getSeparator(): string
+    {
+        return $this->separator;
+    }
+
+    public function setSeparator(string $separator)
+    {
+        $this->separator = $separator;
+        return $this;
+    }
+
+    public function getTypeDefinition(): array
+    {
+        $properties = parent::getTypeDefinition();
+
+        $properties[] = 'SEPARATOR';
+        $properties[] = $this->getSeparator();
+
+        if ($this->isSortable()) {
+            $properties[] = 'SORTABLE';
+        }
+
+        if ($this->isNoindex()) {
+            $properties[] = 'NOINDEX';
+        }
+
+        return $properties;
+    }
+}

--- a/src/Index.php
+++ b/src/Index.php
@@ -155,8 +155,6 @@ class Index extends AbstractIndex implements IndexInterface
      */
     protected function rawCommand(string $command, array $arguments)
     {
-        print_r($command);
-        print_r($arguments);
         return $this->redisClient->rawCommand($command, $arguments);
     }
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -10,6 +10,7 @@ use Ehann\RediSearch\Exceptions\NoFieldsInIndexException;
 use Ehann\RediSearch\Fields\FieldInterface;
 use Ehann\RediSearch\Fields\GeoField;
 use Ehann\RediSearch\Fields\NumericField;
+use Ehann\RediSearch\Fields\TagField;
 use Ehann\RediSearch\Fields\TextField;
 use Ehann\RediSearch\Query\Builder as QueryBuilder;
 use Ehann\RediSearch\Query\BuilderInterface as QueryBuilderInterface;
@@ -110,6 +111,19 @@ class Index extends AbstractIndex implements IndexInterface
     }
 
     /**
+     * @param string $name
+     * @param string $separator
+     * @param bool $sortable
+     * @param bool $noindex
+     * @return IndexInterface
+     */
+    public function addTagField(string $name, string $separator = ',', bool $sortable = false, bool $noindex = false): IndexInterface
+    {
+        $this->$name = (new TagField($name))->setSeparator($separator)->setSortable($sortable)->setNoindex($noindex);
+        return $this;
+    }
+
+    /**
      * @return mixed
      */
     public function drop()
@@ -141,6 +155,8 @@ class Index extends AbstractIndex implements IndexInterface
      */
     protected function rawCommand(string $command, array $arguments)
     {
+        print_r($command);
+        print_r($arguments);
         return $this->redisClient->rawCommand($command, $arguments);
     }
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -117,9 +117,9 @@ class Index extends AbstractIndex implements IndexInterface
      * @param bool $noindex
      * @return IndexInterface
      */
-    public function addTagField(string $name, string $separator = ',', bool $sortable = false, bool $noindex = false): IndexInterface
+    public function addTagField(string $name, bool $sortable = false, bool $noindex = false, string $separator = ','): IndexInterface
     {
-        $this->$name = (new TagField($name))->setSeparator($separator)->setSortable($sortable)->setNoindex($noindex);
+        $this->$name = (new TagField($name))->setSortable($sortable)->setNoindex($noindex)->setSeparator($separator);
         return $this;
     }
 

--- a/tests/RediSearch/IndexTest.php
+++ b/tests/RediSearch/IndexTest.php
@@ -115,6 +115,18 @@ class IndexTest extends AbstractTestCase
         $this->assertTrue($result);
     }
 
+    public function testCreateIndexWithTagField()
+    {
+        $indexName = 'IndexWithTag';
+        $index = (new TestIndex($this->redisClient, $indexName))
+            ->addTextField('title', true)
+            ->addTagField('tagfield', ',', true, false);
+
+
+        $result = $index->create();
+        $this->assertTrue($result);
+    }
+
     public function testAddDocumentWithZeroScore()
     {
         $this->subject->create();

--- a/tests/RediSearch/IndexTest.php
+++ b/tests/RediSearch/IndexTest.php
@@ -120,7 +120,7 @@ class IndexTest extends AbstractTestCase
         $indexName = 'IndexWithTag';
         $index = (new TestIndex($this->redisClient, $indexName))
             ->addTextField('title', true)
-            ->addTagField('tagfield', ',', true, false);
+            ->addTagField('tagfield', true, false, ',');
 
 
         $result = $index->create();


### PR DESCRIPTION
This adds the support for `Index::addTagField`, as requested in #32 (and also needed by myself)