### PR TITLE
Adding possibility to add aliases to reducers

### DIFF
--- a/src/Aggregate/Reducers/AbstractFieldNameReducer.php
+++ b/src/Aggregate/Reducers/AbstractFieldNameReducer.php
@@ -7,14 +7,24 @@ use Ehann\RediSearch\CanBecomeArrayInterface;
 abstract class AbstractFieldNameReducer implements CanBecomeArrayInterface
 {
     public $fieldName;
+    public $alias;
 
-    public function __construct(string $fieldName)
+    public function __construct(string $fieldName, string $alias = '')
     {
         $this->fieldName = $fieldName;
+        $this->alias = $alias;
     }
 
     public function toArray(): array
     {
         return [];
+    }
+
+    protected function addAlias($params) {
+        if(empty($this->alias)) {
+            return $params;
+        }
+
+        return array_merge($params, ['AS', $this->alias]);
     }
 }

--- a/src/Aggregate/Reducers/CountDistinct.php
+++ b/src/Aggregate/Reducers/CountDistinct.php
@@ -6,6 +6,6 @@ class CountDistinct extends AbstractFieldNameReducer
 {
     public function toArray(): array
     {
-        return ['REDUCE', 'COUNT_DISTINCT', '1', $this->fieldName];
+        return $this->addAlias(['REDUCE', 'COUNT_DISTINCT', '1', $this->fieldName]);
     }
 }


### PR DESCRIPTION
I needed add an alias to a reducer result.

The documentation allows `AS` for every reducer. I only implemented it for the one I'm using right now, because I wanted to get input from you on how you want this implemented.

Greetings,
Philipp