### PR TITLE
Fix installing Laravel client using composer

### DIFF
--- a/docs/laravel-support/index.html
+++ b/docs/laravel-support/index.html
@@ -513,7 +513,7 @@
 It provides a <a href="https://laravel.com/docs/5.6/scout">Laravel Scout</a> driver.</p>
 <h2 id="getting-started">Getting Started<a class="headerlink" href="#getting-started" title="Permanent link">&para;</a></h2>
 <h3 id="install">Install<a class="headerlink" href="#install" title="Permanent link">&para;</a></h3>
-<div class="codehilite"><pre><span></span>composer install ethanhann/laravel-redisearch
+<div class="codehilite"><pre><span></span>composer require ethanhann/laravel-redisearch
 </pre></div>
 
 <h3 id="register-the-provider">Register the Provider<a class="headerlink" href="#register-the-provider" title="Permanent link">&para;</a></h3>


### PR DESCRIPTION
Hi @ethanhann 
Thanks for this great implementation. I found a small mistake in the docs:

```
composer install ethanhann/laravel-redisearch
```

where it should be 

```
composer require ethanhann/laravel-redisearch
```

I know it's silly to send a PR for this but, nah :D