### PR TITLE
Fix build due to dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ before_install:
   - docker run -d -p 6379:6379 redislabs/redisearch:latest --protected-mode no --loadmodule /usr/lib/redis/modules/redisearch.so
 language: php
 php:
-  - '7.0'
-  - '7.1'
-  - '7.2'
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4snapshot
 before_script:
   - printf "yes\n" | pecl install igbinary
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
 before_script:
   - printf "yes\n" | pecl install igbinary
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
         "ethanhann/redis-raw": "^0.3"
     },
     "require-dev": {
-        "ukko/phpredis-phpdoc": "^2.2@dev",
         "phpunit/phpunit": "^6.0",
         "mockery/mockery": "^0.9.9",
         "predis/predis": "^1.1",
         "friendsofphp/php-cs-fixer": "^2.2",
         "consolidation/robo": "^1.0",
         "monolog/monolog": "^1.23",
-        "cheprasov/php-redis-client": "^1.8"
+        "cheprasov/php-redis-client": "^1.8",
+        "ukko/phpredis-phpdoc": "^5.0@beta"
     }
 }


### PR DESCRIPTION
current master failed as seen here:
https://travis-ci.org/ethanhann/redisearch-php/builds/564840612?utm_source=github_status&utm_medium=notification

```
  Problem 1
    - The requested package ukko/phpredis-phpdoc ^2.2@dev exists as ukko/phpredis-phpdoc[5.0.1-beta1, 5.0.1-beta2, 5.0.1-beta3, 5.0.1-beta4, 5.0.1-beta5, dev-fix-bool-types, dev-master] but these are rejected by your constraint.
```