### PR TITLE
explicitly require php less than 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7",
+        "php": ">=7 <8.0",
         "psr/log": "^1.0",
         "ethanhann/redis-raw": "^0.3"
     },


### PR DESCRIPTION
php 8 deprecated `null` as parameter for `explode()` so running redisearch-php on php 8+ will throw deprecation error