### PR TITLE
Fix index creation adding prefix

### DIFF
--- a/src/Index.php
+++ b/src/Index.php
@@ -29,6 +29,8 @@ class Index extends AbstractIndex implements IndexInterface
     private $noFrequenciesEnabled = false;
     /** @var array */
     private $stopWords = null;
+    /** @var array|null  */
+    private $prefixes;
 
     /**
      * @return mixed
@@ -38,6 +40,11 @@ class Index extends AbstractIndex implements IndexInterface
     {
         $properties = [$this->getIndexName()];
 
+        if (!is_null($this->prefixes)) {
+            $properties[] = 'PREFIX';
+            $properties[] = count($this->prefixes);
+            $properties = array_merge($properties, $this->prefixes);
+        }
         if ($this->isNoOffsetsEnabled()) {
             $properties[] = 'NOOFFSETS';
         }
@@ -299,6 +306,18 @@ class Index extends AbstractIndex implements IndexInterface
     public function setStopWords(array $stopWords = []): IndexInterface
     {
         $this->stopWords = $stopWords;
+        return $this;
+    }
+
+    /**
+     * @param array $prefixes
+     *
+     * @return IndexInterface
+     */
+    public function setPrefixes(array $prefixes = []): IndexInterface
+    {
+        $this->prefixes = $prefixes;
+
         return $this;
     }
 

--- a/src/IndexInterface.php
+++ b/src/IndexInterface.php
@@ -27,6 +27,7 @@ interface IndexInterface extends BuilderInterface
     public function isNoFrequenciesEnabled(): bool;
     public function setNoFrequenciesEnabled(bool $noFieldsEnabled): IndexInterface;
     public function setStopWords(array $stopWords): IndexInterface;
+    public function setPrefixes(array $prefixes): IndexInterface;
     public function addTextField(string $name, float $weight = 1.0, bool $sortable = false, bool $noindex = false): IndexInterface;
     public function addNumericField(string $name, bool $sortable = false, bool $noindex = false): IndexInterface;
     public function addGeoField(string $name, bool $noindex = false): IndexInterface;

--- a/tests/RediSearch/IndexTest.php
+++ b/tests/RediSearch/IndexTest.php
@@ -747,6 +747,16 @@ class IndexTest extends RediSearchTestCase
         $this->assertEquals(1, $result->getCount());
     }
 
+    public function testSetPrefixesOnCreateIndex()
+    {
+        $expected = 'Foo';
+        $this->subject->setPrefixes([$expected])->create();
+
+        $info = $this->subject->info();
+
+        $this->assertSame($expected, $info[5][3][0]);
+    }
+
     public function testShouldCreateIndexWithNoFrequencies()
     {
         $this->subject->setNoFrequenciesEnabled(true)->create();


### PR DESCRIPTION
The Prefix is missing when we create indexes and it is necessary when we work with multiple indexes.
It tells the index which keys it should index because on Redisearch 2.* when we add document with HSET we don't specify the index to link the document.
Without this, when we work with multiple indexes, all indexes contain all documents and when you delete one index, it deletes all documents of all indexes, similarly when we search on one index it searches in all the documents of all the indexes.
https://redis.com/blog/redisearch-2-0-hits-its-first-milestone/#:~:text=PREFIX%20%7Bcount%7D%20%7Bprefix%7D%20tells%20the%20index%20which%20keys%20it%20should%20index.%20You%20can%20add%20several%20prefixes%20to%20index.%20Since%20the%20argument%20is%20optional%2C%20the%20default%20is%20*%20(all%20keys).

I have tested this fix on real condition, but I don't have the environment to launch the unit test that I have created in the PR so I don't know if the test is really on success.