### PR TITLE
Fix PHP 8.4+ compatibility

### DIFF
--- a/src/AbstractIndex.php
+++ b/src/AbstractIndex.php
@@ -9,7 +9,7 @@ abstract class AbstractIndex extends AbstractRediSearchClientAdapter
     /** @var string */
     protected $indexName;
 
-    public function __construct(RedisRawClientInterface $redisClient = null, string $indexName = '')
+    public function __construct(?RedisRawClientInterface $redisClient = null, string $indexName = '')
     {
         parent::__construct($redisClient);
         $this->indexName = $indexName;

--- a/src/AbstractRediSearchClientAdapter.php
+++ b/src/AbstractRediSearchClientAdapter.php
@@ -9,7 +9,7 @@ abstract class AbstractRediSearchClientAdapter
     /** @var RediSearchRedisClient */
     protected $redisClient;
 
-    public function __construct(RedisRawClientInterface $redisClient = null)
+    public function __construct(?RedisRawClientInterface $redisClient = null)
     {
         $this->redisClient = new RediSearchRedisClient($redisClient);
     }

--- a/src/Aggregate/Builder.php
+++ b/src/Aggregate/Builder.php
@@ -69,7 +69,7 @@ class Builder implements BuilderInterface
      * @param CanBecomeArrayInterface|array $reducer
      * @return BuilderInterface
      */
-    public function groupBy($fieldName = [], CanBecomeArrayInterface $reducer = null): BuilderInterface
+    public function groupBy($fieldName = [], ?CanBecomeArrayInterface $reducer = null): BuilderInterface
     {
         $this->pipeline[] = new GroupBy(is_array($fieldName) ? $fieldName : [$fieldName]);
         if (!is_null($reducer)) {
@@ -185,7 +185,7 @@ class Builder implements BuilderInterface
      * @param bool $isAscending
      * @return BuilderInterface
      */
-    public function firstValue(string $fieldName, string $byFieldName = null, bool $isAscending = true): BuilderInterface
+    public function firstValue(string $fieldName, ?string $byFieldName = null, bool $isAscending = true): BuilderInterface
     {
         $this->pipeline[] = new FirstValue($fieldName, $byFieldName, $isAscending);
         return $this;

--- a/src/Aggregate/BuilderInterface.php
+++ b/src/Aggregate/BuilderInterface.php
@@ -7,7 +7,7 @@ use Ehann\RediSearch\CanBecomeArrayInterface;
 interface BuilderInterface
 {
     public function load(array $fieldNames): BuilderInterface;
-    public function groupBy($fieldName, CanBecomeArrayInterface $reducer = null): BuilderInterface;
+    public function groupBy($fieldName, ?CanBecomeArrayInterface $reducer = null): BuilderInterface;
     public function reduce(CanBecomeArrayInterface $reducer): BuilderInterface;
     public function sortBy($fieldName, $isAscending = true, int $max = -1): BuilderInterface;
     public function apply(string $expression, string $asName): BuilderInterface;
@@ -22,7 +22,7 @@ interface BuilderInterface
     public function max(string $fieldName): BuilderInterface;
     public function min(string $fieldName): BuilderInterface;
     public function standardDeviation(string $fieldName): BuilderInterface;
-    public function firstValue(string $fieldName, string $byFieldName = null, bool $isAscending = true): BuilderInterface;
+    public function firstValue(string $fieldName, ?string $byFieldName = null, bool $isAscending = true): BuilderInterface;
     public function quantile(string $fieldName, float $quantile): BuilderInterface;
     public function toList(string $fieldName): BuilderInterface;
 }

--- a/src/Aggregate/Reducers/AbstractFieldNameReducer.php
+++ b/src/Aggregate/Reducers/AbstractFieldNameReducer.php
@@ -24,6 +24,6 @@ abstract class AbstractFieldNameReducer implements CanBecomeArrayInterface
 
     protected function makeAlias(): string
     {
-        return empty($alias) ? strtolower($this->reducerKeyword) . "_" . $this->fieldName : $this->alias;
+        return empty($this->alias) ? strtolower($this->reducerKeyword) . "_" . $this->fieldName : $this->alias;
     }
 }

--- a/src/Aggregate/Reducers/FirstValue.php
+++ b/src/Aggregate/Reducers/FirstValue.php
@@ -8,7 +8,7 @@ class FirstValue extends AbstractFieldNameReducer
     public $byFieldName;
     public $isAscending;
 
-    public function __construct(string $fieldName, string $byFieldName = null, bool $isAscending = true)
+    public function __construct(string $fieldName, ?string $byFieldName = null, bool $isAscending = true)
     {
         parent::__construct($fieldName);
         $this->byFieldName = $byFieldName;

--- a/src/Document/Document.php
+++ b/src/Document/Document.php
@@ -2,11 +2,9 @@
 
 namespace Ehann\RediSearch\Document;
 
-use AllowDynamicProperties;
 use Ehann\RediSearch\Exceptions\OutOfRangeDocumentScoreException;
 use Ehann\RediSearch\Fields\FieldInterface;
 
-#[AllowDynamicProperties]
 class Document implements DocumentInterface
 {
     protected $id;
@@ -17,16 +15,32 @@ class Document implements DocumentInterface
     protected $noCreate = false;
     protected $payload;
     protected $language;
+    protected array $fields = [];
 
     public function __construct($id = null)
     {
         $this->id = $id ?? uniqid(true);
     }
 
+    public function __set(string $name, FieldInterface $value): void
+    {
+        $this->fields[$name] = $value;
+    }
+
+    public function __get(string $name): ?FieldInterface
+    {
+        return $this->fields[$name] ?? null;
+    }
+
+    public function __isset(string $name): bool
+    {
+        return isset($this->fields[$name]);
+    }
+
     protected function addFieldsToProperties($properties): array
     {
         /** @var FieldInterface $field */
-        foreach (get_object_vars($this) as $field) {
+        foreach ($this->fields as $field) {
             if ($field instanceof FieldInterface && !is_null($field->getValue())) {
                 $properties[] = $field->getName();
                 $properties[] = $field->getValue();
@@ -35,7 +49,7 @@ class Document implements DocumentInterface
         return $properties;
     }
 
-    public function getHashDefinition(array $prefixes = null): array
+    public function getHashDefinition(?array $prefixes = null): array
     {
         $id = $this->getId();
         $completeId = !is_null($prefixes) && count($prefixes) > 0 ?

--- a/src/Exceptions/AliasDoesNotExistException.php
+++ b/src/Exceptions/AliasDoesNotExistException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class AliasDoesNotExistException extends Exception
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(
             trim("Alias does not exist. $message"),

--- a/src/Exceptions/DocumentAlreadyInIndexException.php
+++ b/src/Exceptions/DocumentAlreadyInIndexException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class DocumentAlreadyInIndexException extends Exception
 {
-    public function __construct($indexName, $documentId, $code = 0, Exception $previous = null)
+    public function __construct($indexName, $documentId, $code = 0, ?Exception $previous = null)
     {
         parent::__construct("Document ($documentId) already in index ($indexName).", $code, $previous);
     }

--- a/src/Exceptions/FieldNotInSchemaException.php
+++ b/src/Exceptions/FieldNotInSchemaException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class FieldNotInSchemaException extends Exception
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(trim("The field is not a property in the index. $message"), $code, $previous);
     }

--- a/src/Exceptions/NoFieldsInIndexException.php
+++ b/src/Exceptions/NoFieldsInIndexException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class NoFieldsInIndexException extends Exception
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(
             trim("There needs to be at least one field defined as a property in the index. $message"),

--- a/src/Exceptions/OutOfRangeDocumentScoreException.php
+++ b/src/Exceptions/OutOfRangeDocumentScoreException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class OutOfRangeDocumentScoreException extends Exception
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(trim("Document scores must be normalized between 0.0 ... 1.0. $message"), $code, $previous);
     }

--- a/src/Exceptions/UnknownIndexNameException.php
+++ b/src/Exceptions/UnknownIndexNameException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class UnknownIndexNameException extends Exception
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(
             trim("Unknown index name. $message"),

--- a/src/Exceptions/UnknownIndexNameOrNameIsAnAliasItselfException.php
+++ b/src/Exceptions/UnknownIndexNameOrNameIsAnAliasItselfException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class UnknownIndexNameOrNameIsAnAliasItselfException extends Exception
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(
             trim("Unknown index name (or name is an alias itself). $message"),

--- a/src/Exceptions/UnknownRediSearchCommandException.php
+++ b/src/Exceptions/UnknownRediSearchCommandException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class UnknownRediSearchCommandException extends Exception
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(
             trim("Unknown RediSearch command. Are you sure the RediSearch module is enabled in Redis? $message"),

--- a/src/Exceptions/UnsupportedRediSearchLanguageException.php
+++ b/src/Exceptions/UnsupportedRediSearchLanguageException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class UnsupportedRediSearchLanguageException extends Exception
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(trim("Unsupported language. $message"), $code, $previous);
     }

--- a/src/Index.php
+++ b/src/Index.php
@@ -371,7 +371,7 @@ class Index extends AbstractIndex implements IndexInterface
      * @param array|null $charactersToEscape
      * @return QueryBuilderInterface
      */
-    public function tagFilter(string $fieldName, array $values, array $charactersToEscape = null): QueryBuilderInterface
+    public function tagFilter(string $fieldName, array $values, ?array $charactersToEscape = null): QueryBuilderInterface
     {
         return $this->makeQueryBuilder()->tagFilter($fieldName, $values, $charactersToEscape);
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -128,7 +128,7 @@ class Builder implements BuilderInterface
         return $this;
     }
 
-    public function tagFilter(string $fieldName, array $values, array $charactersToEscape = null): BuilderInterface
+    public function tagFilter(string $fieldName, array $values, ?array $charactersToEscape = null): BuilderInterface
     {
         if ($charactersToEscape == null) {
             $charactersToEscape = [' ', '-'];

--- a/src/Query/BuilderInterface.php
+++ b/src/Query/BuilderInterface.php
@@ -18,7 +18,7 @@ interface BuilderInterface
     public function withPayloads(): BuilderInterface;
     public function withScores(): BuilderInterface;
     public function verbatim(): BuilderInterface;
-    public function tagFilter(string $fieldName, array $values, array $charactersToEscape = null): BuilderInterface;
+    public function tagFilter(string $fieldName, array $values, ?array $charactersToEscape = null): BuilderInterface;
     public function numericFilter(string $fieldName, $min, $max = null): BuilderInterface;
     public function geoFilter(string $fieldName, float $longitude, float $latitude, float $radius, string $distanceUnit = 'km'): BuilderInterface;
     public function sortBy(string $fieldName, $order = 'ASC'): BuilderInterface;

--- a/tests/Stubs/TestIndex.php
+++ b/tests/Stubs/TestIndex.php
@@ -2,10 +2,8 @@
 
 namespace Ehann\Tests\Stubs;
 
-use AllowDynamicProperties;
 use Ehann\RediSearch\Index;
 
-#[AllowDynamicProperties]
 class TestIndex extends Index
 {
 }


### PR DESCRIPTION
## Summary

- **Fix 20 implicitly nullable typed parameters** — PHP 8.4 deprecated `function foo(Type $param = null)`, requiring `?Type $param = null` instead. This will become a TypeError in PHP 9.0. Fixed across all source files and exception classes.

- **Refactor `Document` to eliminate `#[AllowDynamicProperties]`** — `#[AllowDynamicProperties]` was deprecated in PHP 8.4 and will be removed in PHP 9.0. Replaced dynamic property usage with an internal `$fields` array and `__get`/`__set`/`__isset` magic methods (same pattern already used by the `Index` class). Removed the attribute from `TestIndex` as well.

- **Fix bug in `AbstractFieldNameReducer::makeAlias()`** — was referencing undefined variable `$alias` instead of `$this->alias`, causing the alias to never be used.

## Files changed (20)

| File | Change |
|---|---|
| `src/Document/Document.php` | Replace `#[AllowDynamicProperties]` + `get_object_vars()` with `$fields` array; fix `getHashDefinition` param |
| `src/AbstractRediSearchClientAdapter.php` | `?RedisRawClientInterface` |
| `src/AbstractIndex.php` | `?RedisRawClientInterface` |
| `src/Index.php` | `?array $charactersToEscape` |
| `src/Query/Builder.php` | `?array $charactersToEscape` |
| `src/Query/BuilderInterface.php` | `?array $charactersToEscape` |
| `src/Aggregate/Builder.php` | `?CanBecomeArrayInterface`, `?string $byFieldName` |
| `src/Aggregate/BuilderInterface.php` | `?CanBecomeArrayInterface`, `?string $byFieldName` |
| `src/Aggregate/Reducers/FirstValue.php` | `?string $byFieldName` |
| `src/Aggregate/Reducers/AbstractFieldNameReducer.php` | Fix `$alias` → `$this->alias` bug |
| `src/Exceptions/*.php` (9 files) | `?Exception $previous` |
| `tests/Stubs/TestIndex.php` | Remove `#[AllowDynamicProperties]` |

## Test plan

- [ ] Run existing test suite
- [ ] Verify no deprecation warnings on PHP 8.4+
- [ ] Verify Document field get/set behavior works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)